### PR TITLE
Added error handling for video capture in OpenCV code

### DIFF
--- a/docs/intro/intro.rst
+++ b/docs/intro/intro.rst
@@ -95,6 +95,8 @@ and then loop back. The loop finishes when **q** is pressed::
     while True:
         # Capture frame-by-frame
         ret, frame = cap.read()
+        if not ret:
+            break
 
         # Our operations on the frame come here
         gray = cv.cvtColor(frame, cv.COLOR_BGR2GRAY)


### PR DESCRIPTION
ret is a boolean variable returned by the cap.read() function. This function reads the next frame from the video file or camera, and returns True if a frame is successfully read and False if it fails to read a frame.

Therefore, the if not ret condition checks if the frame was successfully read. If the frame was not read (i.e. ret is False), it breaks out of the while loop using the break statement. This is necessary because if there are no more frames to read from the video file, the loop should exit gracefully.